### PR TITLE
Build the wheels with github actions

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,0 +1,49 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, macos-10.15, windows-2019]
+
+    steps:
+      - name: Provide gfortran (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          # https://github.com/actions/virtual-environments/issues/2524
+          # https://github.com/cbg-ethz/dce/blob/master/.github/workflows/pkgdown.yaml
+          sudo ln -s /usr/local/bin/gfortran-11 /usr/local/bin/gfortran
+          sudo mkdir /usr/local/gfortran
+          sudo ln -s /usr/local/Cellar/gcc@11/*/lib/gcc/11 /usr/local/gfortran/lib
+          gfortran --version
+
+      - name: Provide gfortran (Windows)
+        if: runner.os == 'Windows'
+        uses: msys2/setup-msys2@v2
+
+      - name: Tell distutils to use mingw (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          echo "[build]`ncompiler=mingw32" | Out-File -Encoding ASCII ~/pydistutils.cfg
+
+      - uses: actions/checkout@v2
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.0.0
+        env:
+          # Disable building for PyPy and 32bit.
+          CIBW_SKIP: pp* *-win32 *-manylinux_i686
+          # Package the DLL dependencies in the wheel for windows (done by default for the other platforms).
+          # delvewheel cannot mangle the libraries, stripping does not work.
+          CIBW_BEFORE_BUILD_WINDOWS: pip install delvewheel
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel show {wheel} && delvewheel repair -w {dest_dir} {wheel} --no-mangle-all"
+          # Run the tests.
+          CIBW_TEST_COMMAND: python -m unittest pdfo.testpdfo
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl

--- a/setup.py
+++ b/setup.py
@@ -18,11 +18,18 @@ import shutil
 import re
 from os import listdir, remove, walk
 from os.path import dirname, abspath, join, relpath
+import sys
 
 try:
     from numpy.distutils.core import setup, Extension
 except:
     raise Exception('\nPlease install NumPy before installing PDFO.\n')
+
+if sys.platform == "win32":
+    # Fix build with gcc under windows.
+    # See https://github.com/jameskermode/f90wrap/issues/96
+    from numpy.f2py.cfuncs import includes0
+    includes0["setjmp.h"] = '#include <setjmpex.h>'
 
 # Set the paths to all the folders that will be used to build PDFO.
 CURRENT_WD = dirname(abspath(__file__))


### PR DESCRIPTION
Hello,

this PR adds the building of the wheel with github actions, for all the platforms (linux, macos, windows) and all the current python versions (3.6, 3.7, 3.8, 3.9). By installing a `pdfo` wheel, the compilation step and requirements are no longer needed.

This PR has been branched from the v1.0 tag to produce wheels for the latest released version.

Once the CI has run, the wheels can be found in the `Actions` tab in the artifact ([here the one on my repo](https://github.com/AntoineD/pdfo/actions/runs/1079045448)). The github actions pipeline run the tests (`python -m unittest pdfo.testpdfo`) for all the wheels, I also tested them myself locally for linux and windows. All the tests are OK.

On windows, when using a python 3.8 or 3.9 interpreter from anaconda, the [environment variable `CONDA_DLL_SEARCH_MODIFICATION_ENABLE=1` must be defined](https://github.com/ContinuumIO/anaconda-issues/issues/12475) for the wheel to work.

I have not updated the readme files.